### PR TITLE
develop to main

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -4,7 +4,7 @@
 \begin{document}
 \section{Moderncode}
 
-\begin{moderncode}{language=C}{adjusted title={Title}}
+\begin{moderncode}[C][adjusted title={Title}]
 int main(int ac, char *av[])
 {
 	printf("Hello, World");
@@ -12,7 +12,7 @@ int main(int ac, char *av[])
 }
 \end{moderncode}
 
-\begin{moderncode}{language=C}{adjusted title={This title is very very very very very very very very very long}}
+\begin{moderncode}[C][adjusted title={This title is very very very very very very very very very long}]
 int main(int ac, char *av[])
 {
 	printf("Hello, World");
@@ -20,7 +20,7 @@ int main(int ac, char *av[])
 }
 \end{moderncode}
 
-\begin{moderncode}{language=C}{}
+\begin{moderncode}[C]
 int main(int ac, char *av[])
 {
 	printf("Hello, World");
@@ -28,7 +28,7 @@ int main(int ac, char *av[])
 }
 \end{moderncode}
 
-\begin{moderncode}{language=C}{adjusted title={This is a very long code}}
+\begin{moderncode}[C][adjusted title={This is a very long code}]
 int main(int ac, char *av[])
 {
 	printf("Hello, World");
@@ -53,7 +53,7 @@ int main(int ac, char *av[])
 
 \subsection{Output}
 
-\begin{moderncodeout}{}{}
+\begin{moderncodeout}
 Enter a positive integer: 100
 Fibonacci Series: 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89
 \end{moderncodeout}

--- a/moderncode.sty
+++ b/moderncode.sty
@@ -1,10 +1,10 @@
 %%% MODERN CODE
 % Author: Simon Josef Kreuzpointner
-% Date: 06.03.2024
-% Version: 0.2.0
+% Date: 19.03.2024
+% Version: 0.3.0
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{moderncode}[2024/03/06 modern code]
+\ProvidesPackage{moderncode}[2024/03/19 modern code]
 
 \RequirePackage[utf8]{inputenc} % input encoding
 \RequirePackage[T1]{fontenc} % font encoding for umlaute

--- a/moderncode.sty
+++ b/moderncode.sty
@@ -22,7 +22,7 @@
 \tcbuselibrary{listingsutf8}
 \tcbuselibrary{breakable}
 
-\NewTotalTCBox{\moderncodeinline}{O{}v}{
+\NewTotalTCBox{\moderncodeinline}{ O{} v }{%
     verbatim,
     arc=2pt,
     boxsep=0.2em,
@@ -38,7 +38,7 @@
     \lstinline[language=#1]^#2^%
 }
 
-\NewTotalTCBox{\moderncodekey}{v}{
+\NewTotalTCBox{\moderncodekey}{ v }{%
     verbatim,
     enhanced,
     arc=1pt,
@@ -57,7 +57,7 @@
     \lstinline[basicstyle=\sffamily\small]^#1^%
 }
 
-\newtcblisting{moderncode}[2]{
+\DeclareTCBListing{moderncode}{ O{} O{} }{%
     listing only,
     arc=3pt,
     boxsep=0.5em,
@@ -82,7 +82,7 @@
             belowskip=0ex,
             frame=,
             stepnumber=1,
-            #1%
+            language=#1%
         },
     halign title=center,
     coltitle=codegray,
@@ -91,7 +91,7 @@
     #2%
 }
 
-\newtcblisting{moderncodeout}[2]{
+\DeclareTCBListing{moderncodeout}{ O{} O{} }{
     listing only,
     arc=3pt,
     boxsep=0.5em,
@@ -158,6 +158,7 @@
     showtabs=false,
     stepnumber=1,
     tabsize=4,
+    mathescape=true,
     escapeinside={(*}{*)},
     linewidth=\textwidth,
     postbreak=\mbox{\textcolor{codegray}{\(\hookrightarrow\)}\space},


### PR DESCRIPTION
- add `mathescape` to standard `lstlisting` style
- change the arguments of the `moderncode` and `moderncodeout` environment to be optional. The first argument controls settings for the internal `listing`. The first entry will always be interpreted as a language. The second optional argument controls settings for the `tcolorbox`