### PR TITLE
develop to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ This is done for ease of use, as usually no further keys are required.
 ![grafik](https://github.com/Smonman/moderncode/assets/36928284/003b1408-d9ac-4be2-8612-795bc54bcefe)
 
 ## Changelog
+
+### 0.6.1
+
+- fix an error when using `monderncode` with `minted` with no language given
+
 ### 0.6.0
 
 - add support for `minted`, this can be selected through the `minted` package option

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This is done for ease of use, as usually no further keys are required.
 
 ### 0.6.1
 
-- fix an error when using `monderncode` with `minted` with no language given
+- fix an error when using `moderncode` with `minted` with no language given
 
 ### 0.6.0
 

--- a/moderncode.sty
+++ b/moderncode.sty
@@ -1,10 +1,10 @@
 %%% MODERN CODE
 % Author: Simon Josef Kreuzpointner
-% Date: 26.04.2026
-% Version: 0.6.0
+% Date: 15.05.2026
+% Version: 0.6.1
 
 \NeedsTeXFormat{LaTeX2e}%
-\ProvidesPackage{moderncode}[2026/04/26 modern code]%
+\ProvidesPackage{moderncode}[2026/05/15 modern code]%
 
 %%% Required Packages
 \RequirePackage[utf8]{inputenc}% input encoding
@@ -307,7 +307,7 @@
     }{%
         {\sffamily\small#1}%
     }
-    \NewTCBInputListing{\moderncodeinput}{ O{} O{} O{} m }{%
+    \NewTCBInputListing{\moderncodeinput}{ O{text} O{} O{} m }{%
         listing only,
         moderncode,
         minted language={#1},
@@ -317,7 +317,7 @@
         listing file={#4},
         #3%
     }
-    \DeclareTCBListing{moderncode}{ O{} O{} !O{} }{%
+    \DeclareTCBListing{moderncode}{ O{text} O{} !O{} }{%
         listing only,
         moderncode,
         minted language={#1},
@@ -329,6 +329,7 @@
     \DeclareTCBListing{moderncodeout}{ O{} !O{} }{
         listing only,
         moderncode,
+        minted language={text},
         minted options={
                 linenos=none,
                 numbersep=0pt,


### PR DESCRIPTION
- fix an error when using `moderncode` with `minted` with no language given